### PR TITLE
debounce click event

### DIFF
--- a/lib/exportCsv.js
+++ b/lib/exportCsv.js
@@ -14,8 +14,10 @@ function triggerDownload(csv, fileTitle) {
       link.setAttribute('download', exportedFilename);
       link.style.visibility = 'hidden';
       document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
+      window.setTimeout(() => {
+        link.click();
+        document.body.removeChild(link);
+      }, 50); // Need to debounce this click event from others (Pane actionMenuItems dropdown)
     } else {
       console.error('Failed to trigger download for CSV data'); // eslint-disable-line no-console
     }


### PR DESCRIPTION
I found in testing that when `exportToCsv` was called by a dropdown, the download was not triggered. If called by a button, the download was triggered. @JohnC-80 suggested

> The first click might be swallowed by rootCloseWrapper's click to close the dropdown

This PR adds a 50ms delay to separate the clicks and successfully trigger the download.