### PR TITLE
refactor list transform

### DIFF
--- a/lib/exportCsv.js
+++ b/lib/exportCsv.js
@@ -60,11 +60,16 @@ class FieldList {
     return this;
   }
 }
-export default function exportToCsv(objectArray, options) {
+export default function exportToCsv(objectArray, opts) {
   if (!(objectArray && objectArray.length > 0)) {
     // console.debug('No data to export');
     return;
   }
+  let options = opts;
+  if (opts.isArray) { // backwards-compatiblity
+    options = { excludeFields: opts };
+  }
+
   const {
     excludeFields,           // do not include these fields
     explicitlyIncludeFields, // ensure to include these fields

--- a/lib/exportCsv.js
+++ b/lib/exportCsv.js
@@ -49,6 +49,7 @@ class FieldList {
     });
     return this;
   }
+
   ensureToInclude = (includedFields = []) => {
     includedFields.forEach((field) => {
       const index = this.list.indexOf(field);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-util",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A library of utility functions to support Stripes modules.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-util",


### PR DESCRIPTION
I previously made the assumption that the first object in the array has all the fields. In the case of ui-requests, another object in the array may have additional fields. Rather than iterate over all the objects to find the set of unique fields, I added two new options:

- explicitlyIncludeFields: a list of known fields that may not be present on all objects and should be included
- onlyFields: an enumerated list of all fields that should be used