### PR TITLE
Export csv export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-util
 
+## [1.2.0](https://github.com/folio-org/stripes-util/tree/v1.2.0) (2018-10-05)
+
+* Export `exportToCsv`
+
 ## [1.1.0](https://github.com/folio-org/stripes-util/tree/v1.1.0) (2018-09-27)
 
 * Add `options` param to `exportToCsv`. Fixes [UIREQ-102](https://issues.folio.org/browse/UIREQ-102).

--- a/index.js
+++ b/index.js
@@ -1,3 +1,2 @@
-// this rule should be removed after we add more util functions
-// eslint-disable-next-line import/prefer-default-export
 export { default as getFullName } from './lib/getFullName';
+export { default as exportCsv } from './lib/exportCsv';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-util",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A library of utility functions to support Stripes modules.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-util",


### PR DESCRIPTION
Fixes 
```
WARNING in ./node_modules/@folio/requests/src/Requests.js 104:10-21
"export 'exportToCsv' was not found in '@folio/stripes/util' 
```
for https://issues.folio.org/browse/FOLIO-1547

Includes `v1.2.0` release.