### PR TITLE
turned off sideEffects to enable tree-shaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for stripes-util
 
+## 1.3.1 (IN-PROGRESS)
+* Turned off sideEffects to enable tree-shaking for production builds. Refs STRIPES-564 and STRIPES-581.
+
 ## [1.3.0](https://github.com/folio-org/stripes-util/tree/v1.3.0) (2018-11-29)
 
 * Allow CSV export to Use UI labels as column headers

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A library of utility functions to support Stripes modules.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-util",
+  "sideEffects": ["*.css"],
   "publishConfig": {
     "registry": "https://repository.folio.org/repository/npm-folio/"
   },


### PR DESCRIPTION
- Tested with sample "Hello World" UI app. No difference in bundle size but this will shake future unused code blocks.