### PR TITLE
Add validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-util
 
+## 1.5.0 (IN PROGRESS)
+
+* Begin a [library of validator functions](validators), currently only providing `required`.
+
 ## [1.4.0](https://github.com/folio-org/stripes-util/tree/v1.4.0) (2019-05-10)
 [Full Changelog](https://github.com/folio-org/stripes-util/compare/v1.3.0...v1.4.0)
 

--- a/index.js
+++ b/index.js
@@ -1,2 +1,3 @@
 export { default as getFullName } from './lib/getFullName';
 export { default as exportCsv } from './lib/exportCsv';
+export * from './validators';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-util",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "A library of utility functions to support Stripes modules.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-util",
@@ -23,6 +23,10 @@
   "dependencies": {
     "json2csv": "^4.2.1",
     "lodash": "^4.17.4",
+    "react-intl": "^2.4.0",
     "query-string": "^5.0.0"
+  },
+  "peerDependencies": {
+    "react": "*"
   }
 }

--- a/validators/README.md
+++ b/validators/README.md
@@ -1,0 +1,11 @@
+This directory contains validator functions to be used with [redux-form](https://github.com/erikras/redux-form) fields.
+
+Use as follows:
+
+	import { required, etc } from '@folio/stripes-util/validators';
+	// ...
+	<Field name="title" validate={required} />
+
+The following validators are currently provided:
+
+* `required` -- fails when the field is empty.

--- a/validators/README.md
+++ b/validators/README.md
@@ -2,7 +2,7 @@ This directory contains validator functions to be used with [redux-form](https:/
 
 Use as follows:
 
-	import { required, etc } from '@folio/stripes-util/validators';
+	import { required, etc } from '@folio/stripes-util';
 	// ...
 	<Field name="title" validate={required} />
 

--- a/validators/index.js
+++ b/validators/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export { default as required } from './required';

--- a/validators/required.js
+++ b/validators/required.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+
+export default value => (
+  !value ? <FormattedMessage id="stripes-core.label.missingRequiredField" /> : undefined
+);


### PR DESCRIPTION
As discussed on Slack recently, we really shouldn't be including copies of all the same redux-form validator functions in multiple UI modules. Here is the framework for providing them as part of stripes-util, including the first validator.