### PR TITLE
UIREQ-366 format effective call number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-util
 
+## 1.6.0 (IN PROGRESS)
+
+* Export `effectiveCallNumber` to format a call number from an item record. Refs UIREQ-366.
+
 ## [1.5.0](https://github.com/folio-org/stripes-util/tree/v1.4.0) (2019-07-22)
 [Full Changelog](https://github.com/folio-org/stripes-util/compare/v1.4.0...v1.5.0)
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
 export { default as getFullName } from './lib/getFullName';
 export { default as exportCsv } from './lib/exportCsv';
+export { default as effectiveCallNumber } from './lib/effectiveCallNumber';
 export * from './validators';

--- a/lib/effectiveCallNumber.js
+++ b/lib/effectiveCallNumber.js
@@ -1,0 +1,30 @@
+import { get } from 'lodash';
+
+/**
+ * Given an item record, return its effective call number as a string.
+ *
+ * The effective call number is composed of the following elements
+ * which are scattered across an item record:
+ *   <EffectiveCallNumberPrefix>
+ *   <EffectiveCallNumber>
+ *   <EffectiveCallNumberSuffix>
+ *   <Volume>
+ *   <Enumeration>
+ *   <Chronology>
+ *   <EffectiveCopy>
+ *
+ * @param {object} item an item record as returned from /inventory/items/${item-id}
+ * @return {string} the effective call number
+ */
+export default function effectiveCallNumber(item) {
+  const parts = [];
+  parts.push(get(item, 'callNumberComponents.prefix', ''));
+  parts.push(get(item, 'callNumberComponents.callNumber', ''));
+  parts.push(get(item, 'callNumberComponents.suffix', ''));
+  parts.push(get(item, 'volume', ''));
+  parts.push(get(item, 'enumeration', ''));
+  parts.push(get(item, 'chronology', ''));
+  parts.push(get(item, 'copyNumbers[0]', ''));
+
+  return parts.join('');
+}


### PR DESCRIPTION
Utility function returns effective call number as a string given an item
record as returned from `/inventory/items/${item-id}`.

Refs [UIREQ-366](https://issues.folio.org/browse/UIREQ-366)