### PR TITLE
Inherit values from holdings records for effectiveCallNumber. Part of STUTL-4

### DIFF
--- a/lib/effectiveCallNumber.js
+++ b/lib/effectiveCallNumber.js
@@ -1,7 +1,7 @@
 import { get } from 'lodash';
 
 /**
- * Given an item and holding record, return its effective call number as a string.
+ * Given an item and holdings record, return its effective call number as a string.
  *
  * The effective call number is composed of the following elements
  * which are scattered across an item record:

--- a/lib/effectiveCallNumber.js
+++ b/lib/effectiveCallNumber.js
@@ -22,7 +22,7 @@ export default function effectiveCallNumber(item, holdingsRecord) {
     get(holdingsRecord, 'callNumberPrefix', '');
   const callNumber = get(item, 'callNumberComponents.callNumber') ||
     get(holdingsRecord, 'callNumber', '');
-  const suffix = get(item, 'callNumberComponents.suffix', '') ||
+  const suffix = get(item, 'callNumberComponents.suffix') ||
     get(holdingsRecord, 'callNumberSuffix', '');
 
   return [

--- a/lib/effectiveCallNumber.js
+++ b/lib/effectiveCallNumber.js
@@ -14,7 +14,7 @@ import { get } from 'lodash';
  *   <EffectiveCopy>
  *
  * @param {object} item an item record as returned from /inventory/items/${item-id}
- * @param {object} holdingsRecord an optional holdings record returned from holdings-storage/holdings/${holdingsrecord-id}
+ * @param {object} holdingsRecord an optional holdings record returned from /holdings-storage/holdings/${holdingsrecord-id}
  * @return {string} the effective call number
  */
 export default function effectiveCallNumber(item, holdingsRecord) {

--- a/lib/effectiveCallNumber.js
+++ b/lib/effectiveCallNumber.js
@@ -1,7 +1,7 @@
 import { get } from 'lodash';
 
 /**
- * Given an item record, return its effective call number as a string.
+ * Given an item and holding record, return its effective call number as a string.
  *
  * The effective call number is composed of the following elements
  * which are scattered across an item record:
@@ -14,17 +14,24 @@ import { get } from 'lodash';
  *   <EffectiveCopy>
  *
  * @param {object} item an item record as returned from /inventory/items/${item-id}
+ * @param {object} holdingsRecord an optional holdings record returned from holdings-storage/holdings/${holdingsrecord-id}
  * @return {string} the effective call number
  */
-export default function effectiveCallNumber(item) {
-  const parts = [];
-  parts.push(get(item, 'callNumberComponents.prefix', ''));
-  parts.push(get(item, 'callNumberComponents.callNumber', ''));
-  parts.push(get(item, 'callNumberComponents.suffix', ''));
-  parts.push(get(item, 'volume', ''));
-  parts.push(get(item, 'enumeration', ''));
-  parts.push(get(item, 'chronology', ''));
-  parts.push(get(item, 'copyNumbers[0]', ''));
+export default function effectiveCallNumber(item, holdingsRecord) {
+  const prefix = get(item, 'callNumberComponents.prefix') ||
+    get(holdingsRecord, 'callNumberPrefix', '');
+  const callNumber = get(item, 'callNumberComponents.callNumber') ||
+    get(holdingsRecord, 'callNumber', '');
+  const suffix = get(item, 'callNumberComponents.suffix', '') ||
+    get(holdingsRecord, 'callNumberSuffix', '');
 
-  return parts.join('');
+  return [
+    prefix,
+    callNumber,
+    suffix,
+    get(item, 'volume', ''),
+    get(item, 'enumeration', ''),
+    get(item, 'chronology', ''),
+    get(item, 'copyNumbers[0]', '')
+  ].join(' ');
 }


### PR DESCRIPTION
Based on the comments in UIIN-750 it looks like when a prefix, suffix or callNumber are not present on the item record they should be inherited from the holdings record. This PR refactors effectiveCallNumber a bit to support that.

https://issues.folio.org/browse/STUTL-4
