### PR TITLE
Use effectiveCallNumberComponents for prefix suffix and callNumber. Part of STUTL-4

### DIFF
--- a/lib/effectiveCallNumber.js
+++ b/lib/effectiveCallNumber.js
@@ -17,13 +17,20 @@ import { get } from 'lodash';
  * @return {string} the effective call number
  */
 export default function effectiveCallNumber(item) {
+  const prefix = get(item, 'effectiveCallNumberComponents.prefix') ||
+    get(item, 'callNumberComponents.prefix', '');
+  const suffix = get(item, 'effectiveCallNumberComponents.suffix') ||
+    get(item, 'callNumberComponents.suffix', '');
+  const callNumber = get(item, 'effectiveCallNumberComponents.callNumber') ||
+    get(item, 'callNumberComponents.callNumber', '');
+
   return [
-    get(item, 'effectiveCallNumberComponents.prefix', ''),
-    get(item, 'effectiveCallNumberComponents.callNumber', ''),
-    get(item, 'effectiveCallNumberComponents.suffix', ''),
+    prefix,
+    callNumber,
+    suffix,
     get(item, 'volume', ''),
     get(item, 'enumeration', ''),
     get(item, 'chronology', ''),
-    get(item, 'copyNumbers[0]', '')
+    get(item, 'copyNumbers[0]', ''),
   ].join(' ');
 }

--- a/lib/effectiveCallNumber.js
+++ b/lib/effectiveCallNumber.js
@@ -14,21 +14,13 @@ import { get } from 'lodash';
  *   <EffectiveCopy>
  *
  * @param {object} item an item record as returned from /inventory/items/${item-id}
- * @param {object} holdingsRecord an optional holdings record returned from /holdings-storage/holdings/${holdingsrecord-id}
  * @return {string} the effective call number
  */
-export default function effectiveCallNumber(item, holdingsRecord) {
-  const prefix = get(item, 'callNumberComponents.prefix') ||
-    get(holdingsRecord, 'callNumberPrefix', '');
-  const callNumber = get(item, 'callNumberComponents.callNumber') ||
-    get(holdingsRecord, 'callNumber', '');
-  const suffix = get(item, 'callNumberComponents.suffix') ||
-    get(holdingsRecord, 'callNumberSuffix', '');
-
+export default function effectiveCallNumber(item) {
   return [
-    prefix,
-    callNumber,
-    suffix,
+    get(item, 'effectiveCallNumberComponents.prefix', ''),
+    get(item, 'effectiveCallNumberComponents.callNumber', ''),
+    get(item, 'effectiveCallNumberComponents.suffix', ''),
     get(item, 'volume', ''),
     get(item, 'enumeration', ''),
     get(item, 'chronology', ''),


### PR DESCRIPTION
Based on the conversation with @marcjohnson-kint we learned that the `effectiveCallNumber` inheritance actually works correctly on the backend and we were using a wrong field. This PR is trying to address it.

https://issues.folio.org/browse/STUTL-4