### PR TITLE
UIDEXP-1: Add configuration support to turn on/off headers adding to csv files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-util
 
+## 1.6.3 (IN PROGRESS)
+
+* Add configuration to turn on/off header adding to csv file. Refs UIDEXP-1.
+
 ## [1.6.2](https://github.com/folio-org/stripes-util/tree/v1.6.2) (2019-12-18)
 [Full Changelog](https://github.com/folio-org/stripes-util/compare/v1.6.1...v1.6.2)
 

--- a/lib/exportCsv.js
+++ b/lib/exportCsv.js
@@ -76,6 +76,7 @@ export default function exportToCsv(objectArray, opts) {
     explicitlyIncludeFields, // ensure to include these fields
     onlyFields,              // Only Fields to be included
     filename,                // Custom filename
+    header = true,           // turn off/on header adding
   } = options;
 
   // The default behavior is to use the keys on the first object as the list of fields
@@ -83,7 +84,7 @@ export default function exportToCsv(objectArray, opts) {
     .omit(excludeFields)
     .ensureToInclude(explicitlyIncludeFields).list;
 
-  const parser = new Parser({ fields, flatten: true });
+  const parser = new Parser({ fields, flatten: true, header });
   const csv = parser.parse(objectArray);
   triggerDownload(csv, filename);
 }


### PR DESCRIPTION
## Purposes

Add ability to turn on/off the headers adding to csv file. This feature is required in the scope of the [ticket](https://issues.folio.org/browse/UIDEXP-1).