### PR TITLE
UIIN-589 utility function to escape CQL query values

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-export { default as getFullName } from './lib/getFullName';
-export { default as exportCsv } from './lib/exportCsv';
 export { default as effectiveCallNumber } from './lib/effectiveCallNumber';
+export { default as escapeCqlValue } from './lib/escapeCqlValue';
+export { default as exportCsv } from './lib/exportCsv';
+export { default as getFullName } from './lib/getFullName';
 export * from './validators';

--- a/lib/escapeCqlValue.js
+++ b/lib/escapeCqlValue.js
@@ -1,0 +1,10 @@
+/**
+ * Escape quote (") and backslash (\) characters in a string by pre-pending
+ * them with a single backslash.
+ *
+ * @param string a string
+ * @return string the input string with quotes and backslashes escaped
+ */
+export default function escapeCqlValue(str) {
+  return str.replace(/"|\\/g, c => '\\' + c);
+}


### PR DESCRIPTION
Provide a utility function to escape quotes `"` and backslashes `\` in
the values inserted into CQL queries.

Refs [UIIN-589](https://issues.folio.org/browse/UIIN-589)