### PR TITLE
UIU-1391: Fix mistake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add configuration to turn on/off header adding to csv file. Refs UIDEXP-1.
 * Extend function `effectiveCallNumber` for being able to use it with loans. Refs UIU-1391.
 * Move `react-intl` to peerDependencies.
+* Fix a mistake in `effectiveCallNumber` function. Fixes UIU-1391.
 
 ## [1.6.2](https://github.com/folio-org/stripes-util/tree/v1.6.2) (2019-12-18)
 [Full Changelog](https://github.com/folio-org/stripes-util/compare/v1.6.1...v1.6.2)

--- a/lib/effectiveCallNumber.js
+++ b/lib/effectiveCallNumber.js
@@ -24,26 +24,19 @@ import {
 export default function effectiveCallNumber(item) {
   const rootItem = item?.item ?? item;
 
-  const prefix = get(rootItem, 'effectiveCallNumberComponents.prefix') ||
-    get(rootItem, 'callNumberComponents.prefix', '');
-  const suffix = get(rootItem, 'effectiveCallNumberComponents.suffix') ||
-    get(rootItem, 'callNumberComponents.suffix', '');
-  const callNumber = get(rootItem, 'effectiveCallNumberComponents.callNumber') ||
-    get(rootItem, 'callNumberComponents.callNumber', '');
+  const prefix = rootItem?.effectiveCallNumberComponents?.prefix ||  rootItem?.callNumberComponents?.prefix;
+  const suffix = rootItem?.effectiveCallNumberComponents?.suffix ||  rootItem?.callNumberComponents?.suffix;
+  const callNumber = rootItem?.effectiveCallNumberComponents?.callNumber ||  rootItem?.callNumberComponents?.callNumber;
 
   const result = compact([
     prefix,
     callNumber,
     suffix,
-    get(rootItem, 'volume', ''),
-    get(rootItem, 'enumeration', ''),
-    get(rootItem, 'chronology', ''),
-    get(rootItem, 'copyNumbers[0]', ''),
+    rootItem?.volume,
+    rootItem?.enumeration,
+    rootItem?.chronology,
+    rootItem?.copyNumbers?.[0],
   ]);
-
-  if (!has(item, 'item')) {
-    result.push(get(rootItem, 'copyNumbers[0]', ''));
-  }
 
   return result.join(' ');
 }

--- a/lib/effectiveCallNumber.js
+++ b/lib/effectiveCallNumber.js
@@ -13,12 +13,12 @@ import { compact } from 'lodash';
  *   <Chronology>
  *   <EffectiveCopy>
  *
- * @param {object} item an item record as returned from /inventory/items/${item-id}
- * @param {object} item returned from circulation/loans with structure {item: {}}
+ * @param {object} instanceItem an item record as returned from /inventory/items/${item-id}
+ * @param {object} instanceItem returned from circulation/loans with structure {item: {}}
  * @return {string} the effective call number
  */
-export default function effectiveCallNumber(item) {
-  const rootItem = item?.item ?? item;
+export default function effectiveCallNumber(instanceItem) {
+  const rootItem = instanceItem?.item ?? instanceItem;
 
   const prefix = rootItem?.effectiveCallNumberComponents?.prefix ||  rootItem?.callNumberComponents?.prefix;
   const suffix = rootItem?.effectiveCallNumberComponents?.suffix ||  rootItem?.callNumberComponents?.suffix;
@@ -31,7 +31,7 @@ export default function effectiveCallNumber(item) {
     rootItem?.volume,
     rootItem?.enumeration,
     rootItem?.chronology,
-    rootItem?.copyNumbers?.[0],
+    rootItem?.copyNumber,
   ]);
 
   return result.join(' ');

--- a/lib/effectiveCallNumber.js
+++ b/lib/effectiveCallNumber.js
@@ -20,9 +20,9 @@ import { compact } from 'lodash';
 export default function effectiveCallNumber(instanceItem) {
   const rootItem = instanceItem?.item ?? instanceItem;
 
-  const prefix = rootItem?.effectiveCallNumberComponents?.prefix ||  rootItem?.callNumberComponents?.prefix;
-  const suffix = rootItem?.effectiveCallNumberComponents?.suffix ||  rootItem?.callNumberComponents?.suffix;
-  const callNumber = rootItem?.effectiveCallNumberComponents?.callNumber ||  rootItem?.callNumberComponents?.callNumber;
+  const prefix = rootItem?.effectiveCallNumberComponents?.prefix || rootItem?.callNumberComponents?.prefix;
+  const suffix = rootItem?.effectiveCallNumberComponents?.suffix || rootItem?.callNumberComponents?.suffix;
+  const callNumber = rootItem?.effectiveCallNumberComponents?.callNumber || rootItem?.callNumberComponents?.callNumber;
 
   const result = compact([
     prefix,

--- a/lib/effectiveCallNumber.js
+++ b/lib/effectiveCallNumber.js
@@ -1,8 +1,4 @@
-import {
-  get,
-  has,
-  compact,
-} from 'lodash';
+import { compact } from 'lodash';
 
 /**
  * Given an item and holdings record, return its effective call number as a string.


### PR DESCRIPTION
# Description
Fix a mistake in `effectiveCallNumber string` formatter, which @zburke noticed in https://github.com/folio-org/stripes-util/pull/30#discussion_r386680164 (thanks @zburke for being attentive!)
Also rewrite code with optional chaining syntax and remove lodash `get`