### PR TITLE
STRIPES-672 upgrade react-intl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-util
 
+## 3.0.0 (IN PROGRESS)
+
+* Upgrade `react-intl` to `^4.5.3`. Refs STRIPES-672.
+
 ## [2.0.0](https://github.com/folio-org/stripes-util/tree/v2.0.0) (2020-03-04)
 [Full Changelog](https://github.com/folio-org/stripes-util/compare/v1.6.2...v2.0.0)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-util",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "A library of utility functions to support Stripes modules.",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-util",
@@ -27,6 +27,6 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-intl": "^2.4.0"
+    "react-intl": "^4.5.3"
   }
 }


### PR DESCRIPTION
Upgrade `react-intl` to `^4.5.3`. Whoops; missed this one when I did the
rest of the stripes-* updates.

Refs STRIPES-672.