### PR TITLE
configure sonarscan narrowly

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,4 +5,5 @@ buildNPM {
   runTest = true
   runTestOptions = ''
   runSonarqube = true
+  sonarScanDirs = './lib'
 }


### PR DESCRIPTION
Point sonarscan at `./lib` only, per https://folio-project.slack.com/archives/C210UCHQ9/p1612190962101400