### PR TITLE
STUTL-14 exportCsv correctly handles legacy array implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 4.2.0 (IN PROGRESS)
 
+* `exportCsv` correctly handles legacy array implementation. Refs STUTL-14.
+
 ## [4.1.0](https://github.com/folio-org/stripes-util/tree/v4.1.0) (2021-02-25)
 [Full Changelog](https://github.com/folio-org/stripes-util/compare/v4.0.0...v4.1.0)
 

--- a/lib/exportCsv.js
+++ b/lib/exportCsv.js
@@ -67,7 +67,7 @@ export default function exportToCsv(objectArray, opts) {
     return;
   }
   let options = opts;
-  if (opts.isArray) { // backwards-compatiblity
+  if (Array.isArray(opts)) { // backwards-compatiblity
     options = { excludeFields: opts };
   }
 

--- a/lib/exportCsv.test.js
+++ b/lib/exportCsv.test.js
@@ -11,6 +11,8 @@ const list = [
 describe('download a CSV file', () => {
   global.URL.createObjectURL = jest.fn();
   global.Blob = jest.fn();
+  jest.mock('Blob')
+
 
   test('with no options', () => {
     const createElementSpy = jest.spyOn(global.document, 'createElement');
@@ -20,6 +22,9 @@ describe('download a CSV file', () => {
     expect(createElementSpy).toHaveBeenCalled();
     expect(appendChildSpy).toHaveBeenCalled();
     expect(global.URL.createObjectURL).toHaveBeenCalled();
+
+    createElementSpy.mockRestore();
+    appendChildSpy.mockRestore();
   });
 
   test('IE 10+', () => {
@@ -28,6 +33,100 @@ describe('download a CSV file', () => {
 
     exportCsv(list, {});
     expect(spy).toHaveBeenCalled();
+  });
+
+  test('options: excludeFields', () => {
+    const l = [
+      { a: 'r1a', b: 'r1b', c: 'r1c' },
+      { a: 'r2a', b: 'r2b', c: 'r2c' },
+      { a: 'r3a', b: 'r3b', c: 'r3c' },
+    ];
+    const lExpect = ['"a"\n"r1a"\n"r2a"\n"r3a"'];
+
+    const createElementSpy = jest.spyOn(global.document, 'createElement');
+    const appendChildSpy = jest.spyOn(global.document.body, 'appendChild');
+
+    exportCsv(l, { excludeFields: ["b", "c"]});
+    expect(Blob).toHaveBeenLastCalledWith(lExpect, { type: 'text/csv;charset=utf-8;' });
+  });
+
+  test('options: excludeFields, non-existent field', () => {
+    const l = [
+      { a: 'r1a', b: 'r1b', c: 'r1c' },
+      { a: 'r2a', b: 'r2b', c: 'r2c' },
+      { a: 'r3a', b: 'r3b', c: 'r3c' },
+    ];
+    const lExpect = ['"a","b","c"\n"r1a","r1b","r1c"\n"r2a","r2b","r2c"\n"r3a","r3b","r3c"'];
+
+    const createElementSpy = jest.spyOn(global.document, 'createElement');
+    const appendChildSpy = jest.spyOn(global.document.body, 'appendChild');
+
+    exportCsv(l, { excludeFields: ["x"]});
+    expect(Blob).toHaveBeenLastCalledWith(lExpect, { type: 'text/csv;charset=utf-8;' });
+  });
+
+  test('exclude fields, legacy array implementation', () => {
+    const l = [
+      { a: 'r1a', b: 'r1b', c: 'r1c' },
+      { a: 'r2a', b: 'r2b', c: 'r2c' },
+      { a: 'r3a', b: 'r3b', c: 'r3c' },
+    ];
+    const lExpect = ['"a"\n"r1a"\n"r2a"\n"r3a"'];
+
+    const createElementSpy = jest.spyOn(global.document, 'createElement');
+    const appendChildSpy = jest.spyOn(global.document.body, 'appendChild');
+
+    exportCsv(l, ["b", "c"]);
+    expect(Blob).toHaveBeenLastCalledWith(lExpect, { type: 'text/csv;charset=utf-8;' });
+  });
+
+  test('options: onlyFields', () => {
+    const l = [
+      { a: 'r1a', b: 'r1b', c: 'r1c' },
+      { a: 'r2a', b: 'r2b', c: 'r2c' },
+      { a: 'r3a', b: 'r3b', c: 'r3c' },
+    ];
+    const lExpect = ['"a"\n"r1a"\n"r2a"\n"r3a"'];
+
+    const createElementSpy = jest.spyOn(global.document, 'createElement');
+    const appendChildSpy = jest.spyOn(global.document.body, 'appendChild');
+
+    exportCsv(l, { onlyFields: ["a"]});
+    expect(Blob).toHaveBeenLastCalledWith(lExpect, { type: 'text/csv;charset=utf-8;' });
+  });
+
+  test('include fields', () => {
+    const l = [
+      { a: 'r1a', b: 'r1b', c: 'r1c' },
+      { a: 'r2a', b: 'r2b', c: 'r2c' },
+      { a: 'r3a', b: 'r3b', c: 'r3c' },
+    ];
+    const lExpect = ['"a","x"\n"r1a",\n"r2a",\n"r3a",'];
+
+    const createElementSpy = jest.spyOn(global.document, 'createElement');
+    const appendChildSpy = jest.spyOn(global.document.body, 'appendChild');
+
+    exportCsv(l, { excludeFields: ["b", "c"], explicitlyIncludeFields: ["x"]});
+    expect(Blob).toHaveBeenLastCalledWith(lExpect, { type: 'text/csv;charset=utf-8;' });
+  });
+
+
+  test('no arguments', () => {
+    const appendChildSpy = jest.spyOn(global.document.body, 'appendChild');
+
+    exportCsv();
+    expect(appendChildSpy).not.toHaveBeenCalled();
+
+    appendChildSpy.mockRestore();
+  });
+
+  test('empty list', () => {
+    const appendChildSpy = jest.spyOn(global.document.body, 'appendChild');
+
+    exportCsv([], {});
+    expect(appendChildSpy).not.toHaveBeenCalled();
+
+    appendChildSpy.mockRestore();
   });
 
 });

--- a/lib/exportCsv.test.js
+++ b/lib/exportCsv.test.js
@@ -11,8 +11,6 @@ const list = [
 describe('download a CSV file', () => {
   global.URL.createObjectURL = jest.fn();
   global.Blob = jest.fn();
-  jest.mock('Blob')
-
 
   test('with no options', () => {
     const createElementSpy = jest.spyOn(global.document, 'createElement');

--- a/lib/exportCsv.test.js
+++ b/lib/exportCsv.test.js
@@ -104,7 +104,7 @@ describe('download a CSV file', () => {
     const createElementSpy = jest.spyOn(global.document, 'createElement');
     const appendChildSpy = jest.spyOn(global.document.body, 'appendChild');
 
-    exportCsv(l, { excludeFields: ["b", "c"], explicitlyIncludeFields: ["x"]});
+    exportCsv(l, { excludeFields: ["b", "c"], explicitlyIncludeFields: ["a", "x"]});
     expect(Blob).toHaveBeenLastCalledWith(lExpect, { type: 'text/csv;charset=utf-8;' });
   });
 


### PR DESCRIPTION
When `exportCsv()` receives an array as a second argument, it
interprets that as a list of fields to exclude from the results.
However, it did not correctly check the type of the argument, preventing
this from ever happening.

Refs [STUTL-14](https://issues.folio.org/browse/STUTL-14)