### PR TITLE
STUTL-15 show exportToCsv deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 4.2.0 (IN PROGRESS)
 
-* `exportCsv` correctly handles legacy array implementation. Refs STUTL-14.
+* `exportToCsv` correctly handles legacy array implementation. Refs STUTL-14.
+* Announce deprecation of `exportToCsv`, now provided in `stripes-components`. Refs STUTL-15.
 
 ## [4.1.0](https://github.com/folio-org/stripes-util/tree/v4.1.0) (2021-02-25)
 [Full Changelog](https://github.com/folio-org/stripes-util/compare/v4.0.0...v4.1.0)

--- a/lib/exportCsv.js
+++ b/lib/exportCsv.js
@@ -62,6 +62,7 @@ class FieldList {
 }
 
 export default function exportToCsv(objectArray, opts) {
+  console.warn('[DEPRECATION] - use "@folio/stripes/components/exportToCsv" instead.');
   if (!(objectArray && objectArray.length > 0)) {
     // console.debug('No data to export');
     return;


### PR DESCRIPTION
Show a console warning that `exportToCsv` is deprecated in this package and has
been moved to `stripes-components`.

Refs [STUTL-15](https://issues.folio.org/browse/STUTL-15)