### PR TITLE
Revert "STUTL-30 replace json2csv"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Change history for stripes-util
 
-## 5.3.0 IN PROGRESS
-
-* Replace `json2csv` with `@json2csv`. Refs STUTL-30.
-
 ## [5.2.1](https://github.com/folio-org/stripes-util/tree/v5.2.1) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-util/compare/v5.2.0...v5.2.1)
 

--- a/lib/exportCsv.js
+++ b/lib/exportCsv.js
@@ -1,6 +1,4 @@
-import { Parser } from '@json2csv/plainjs';
-import { flatten } from '@json2csv/transforms';
-
+import { Parser } from 'json2csv';
 
 function triggerDownload(csv, fileTitle) {
   const exportedFilename = fileTitle ? fileTitle + '.csv' : 'export.csv';
@@ -88,7 +86,7 @@ export default function exportToCsv(objectArray, opts) {
     .omit(excludeFields)
     .ensureToInclude(explicitlyIncludeFields).list;
 
-  const parser = new Parser({ fields, header, transforms: [flatten()] });
+  const parser = new Parser({ fields, flatten: true, header });
   const csv = parser.parse(objectArray);
   triggerDownload(csv, filename);
 }

--- a/lib/exportCsv.test.js
+++ b/lib/exportCsv.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 import exportCsv from './exportCsv';
 
 const list = [

--- a/package.json
+++ b/package.json
@@ -24,19 +24,17 @@
     "@babel/preset-env": "^7.11.5",
     "@babel/preset-react": "^7.10.4",
     "@folio/eslint-config-stripes": "^6.1.0",
-    "@jest/globals": "^29.5.0",
-    "babel-jest": "^29.5.0",
+    "@jest/globals": "^26.4.2",
+    "babel-jest": "^26.3.0",
     "eslint": "^7.32.0",
     "eslint-import-resolver-webpack": "^0.13.2",
-    "jest": "^29.5.0",
-    "jest-environment-jsdom": "^29.5.0",
+    "jest": "^26.4.2",
     "jest-junit": "^11.1.0",
     "react-test-renderer": "^16.13.1",
     "webpack": "^4.10.2"
   },
   "dependencies": {
-    "@json2csv/plainjs": "^6.1.2",
-    "@json2csv/transforms": "^6.1.2",
+    "json2csv": "^4.2.1",
     "lodash": "^4.17.4",
     "query-string": "^7.1.2"
   },


### PR DESCRIPTION
Reverts folio-org/stripes-util#64

Maaaaaaybe this is the cause of failures in other repos, indicating that, across the board, jest needs to be updated to v29, and/or `@json2csv` needs to be added to `jest.config.js::transformIgnorePatterns`. I don't love either of those options, but I guess the "real" problem here is that @folio modules aren't transpiled upon distribution and that's allowing this issue to leak through. 