### PR TITLE
STUTL-30 replace json2csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-util
 
+## 5.3.0 IN PROGRESS
+
+* Replace `json2csv` with `@json2csv`. Refs STUTL-30.
+
 ## [5.2.1](https://github.com/folio-org/stripes-util/tree/v5.2.1) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-util/compare/v5.2.0...v5.2.1)
 

--- a/lib/exportCsv.js
+++ b/lib/exportCsv.js
@@ -1,4 +1,6 @@
-import { Parser } from 'json2csv';
+import { Parser } from '@json2csv/plainjs';
+import { flatten } from '@json2csv/transforms';
+
 
 function triggerDownload(csv, fileTitle) {
   const exportedFilename = fileTitle ? fileTitle + '.csv' : 'export.csv';
@@ -86,7 +88,7 @@ export default function exportToCsv(objectArray, opts) {
     .omit(excludeFields)
     .ensureToInclude(explicitlyIncludeFields).list;
 
-  const parser = new Parser({ fields, flatten: true, header });
+  const parser = new Parser({ fields, header, transforms: [flatten()] });
   const csv = parser.parse(objectArray);
   triggerDownload(csv, filename);
 }

--- a/lib/exportCsv.test.js
+++ b/lib/exportCsv.test.js
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import exportCsv from './exportCsv';
 
 const list = [

--- a/package.json
+++ b/package.json
@@ -24,17 +24,19 @@
     "@babel/preset-env": "^7.11.5",
     "@babel/preset-react": "^7.10.4",
     "@folio/eslint-config-stripes": "^6.1.0",
-    "@jest/globals": "^26.4.2",
-    "babel-jest": "^26.3.0",
+    "@jest/globals": "^29.5.0",
+    "babel-jest": "^29.5.0",
     "eslint": "^7.32.0",
     "eslint-import-resolver-webpack": "^0.13.2",
-    "jest": "^26.4.2",
+    "jest": "^29.5.0",
+    "jest-environment-jsdom": "^29.5.0",
     "jest-junit": "^11.1.0",
     "react-test-renderer": "^16.13.1",
     "webpack": "^4.10.2"
   },
   "dependencies": {
-    "json2csv": "^4.2.1",
+    "@json2csv/plainjs": "^6.1.2",
+    "@json2csv/transforms": "^6.1.2",
     "lodash": "^4.17.4",
     "query-string": "^7.1.2"
   },


### PR DESCRIPTION
`json2csv` was abandoned after v5. Updating to `@json2csv`, an ESM module, also required updating test infrastructure.

Refs [STUTL-30](https://issues.folio.org/browse/STUTL-30)