### PR TITLE
STUTL-32: Add getHeaderWithCredentials for leverage cookie-based authentication in all API requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-util
 
+## IN PROGRESS
+
+* Add `getHeaderWithCredentials` for leverage cookie-based authentication in all API requests. Refs STUTL-32.
+
 ## [5.2.1](https://github.com/folio-org/stripes-util/tree/v5.2.1) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-util/compare/v5.2.0...v5.2.1)
 

--- a/index.js
+++ b/index.js
@@ -3,5 +3,6 @@ export { default as escapeCqlValue } from './lib/escapeCqlValue';
 export { default as exportCsv } from './lib/exportCsv';
 export { default as getFullName } from './lib/getFullName';
 export { default as parseJwt } from './lib/parseJwt';
+export { default as getHeaderWithCredentials } from './lib/getHeaderWithCredentials';
 export * from './validators';
 export * from './lib/permission';

--- a/lib/getHeaderWithCredentials.js
+++ b/lib/getHeaderWithCredentials.js
@@ -1,0 +1,41 @@
+export const REQUEST_PARTS = {
+  HEADERS: 'headers',
+  CREDENTIALS: 'credentials',
+};
+
+export const HEADER_KEYS = {
+  TENANT: 'X-Okapi-Tenant',
+  TOKEN: 'X-Okapi-Token',
+  CONTENT_TYPE: 'Content-Type',
+};
+
+export const CONTENT_TYPES = {
+  JSON: 'application/json',
+};
+
+export const getTenant = (okapi = {}) => (
+  okapi.tenant ? { [HEADER_KEYS.TENANT]: okapi.tenant } : {}
+);
+
+export const getToken = (okapi = {}) => (
+  okapi.token ? { [HEADER_KEYS.TOKEN]: okapi.token } : {}
+);
+
+export const getHeader = (okapi = {}) => (
+  {
+    [REQUEST_PARTS.HEADERS]: {
+      ...getTenant(okapi),
+      ...getToken(okapi),
+      [HEADER_KEYS.CONTENT_TYPE]: CONTENT_TYPES.JSON,
+    },
+  }
+);
+
+export const getHeaderWithCredentials = (okapi = {}) => (
+  {
+    ...getHeader(okapi),
+    [REQUEST_PARTS.CREDENTIALS]: 'include',
+  }
+);
+
+export default getHeaderWithCredentials;

--- a/lib/getHeaderWithCredentials.test.js
+++ b/lib/getHeaderWithCredentials.test.js
@@ -1,0 +1,118 @@
+import {
+  describe,
+  expect,
+  it,
+} from '@jest/globals';
+
+import {
+  REQUEST_PARTS,
+  HEADER_KEYS,
+  CONTENT_TYPES,
+  getTenant,
+  getToken,
+  getHeader,
+  getHeaderWithCredentials,
+} from './getHeaderWithCredentials';
+
+describe('headers', () => {
+  const tenant = 'tenant';
+  const token = 'token';
+
+  describe('getTenant', () => {
+    it('should return tenant', () => {
+      expect(getTenant({
+        tenant,
+      })).toEqual({
+        [HEADER_KEYS.TENANT]: tenant,
+      });
+    });
+
+    it('should return empty object', () => {
+      expect(getTenant()).toEqual({});
+    });
+  });
+
+  describe('getToken', () => {
+    it('should return token', () => {
+      expect(getToken({
+        token,
+      })).toEqual({
+        [HEADER_KEYS.TOKEN]: token,
+      });
+    });
+
+    it('should return empty object', () => {
+      expect(getToken()).toEqual({});
+    });
+  });
+
+  describe('getHeader', () => {
+    it('should return header', () => {
+      expect(getHeader({
+        tenant,
+        token,
+      })).toEqual({
+        [REQUEST_PARTS.HEADERS]: {
+          [HEADER_KEYS.TENANT]: tenant,
+          [HEADER_KEYS.TOKEN]: token,
+          [HEADER_KEYS.CONTENT_TYPE]: CONTENT_TYPES.JSON,
+        },
+      });
+    });
+
+    it('should return header without tenant', () => {
+      expect(getHeader({
+        token,
+      })).toEqual({
+        [REQUEST_PARTS.HEADERS]: {
+          [HEADER_KEYS.TOKEN]: token,
+          [HEADER_KEYS.CONTENT_TYPE]: CONTENT_TYPES.JSON,
+        },
+      });
+    });
+
+    it('should return header without token', () => {
+      expect(getHeader({
+        tenant,
+      })).toEqual({
+        [REQUEST_PARTS.HEADERS]: {
+          [HEADER_KEYS.TENANT]: tenant,
+          [HEADER_KEYS.CONTENT_TYPE]: CONTENT_TYPES.JSON,
+        },
+      });
+    });
+
+    it('should return content types', () => {
+      expect(getHeader()).toEqual({
+        [REQUEST_PARTS.HEADERS]: {
+          [HEADER_KEYS.CONTENT_TYPE]: CONTENT_TYPES.JSON,
+        },
+      });
+    });
+  });
+
+  describe('getHeaderWithCredentials', () => {
+    it('should return header and credentials', () => {
+      expect(getHeaderWithCredentials({
+        tenant,
+        token
+      })).toEqual({
+        [REQUEST_PARTS.HEADERS]: {
+          [HEADER_KEYS.TENANT]: tenant,
+          [HEADER_KEYS.TOKEN]: token,
+          [HEADER_KEYS.CONTENT_TYPE]: CONTENT_TYPES.JSON,
+        },
+        [REQUEST_PARTS.CREDENTIALS]: 'include',
+      });
+    });
+
+    it('should return content types and credentials', () => {
+      expect(getHeaderWithCredentials()).toEqual({
+        [REQUEST_PARTS.HEADERS]: {
+          [HEADER_KEYS.CONTENT_TYPE]: CONTENT_TYPES.JSON,
+        },
+        [REQUEST_PARTS.CREDENTIALS]: 'include',
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Purpose
Leverage cookie-based authentication in all API requests

## Refs
https://issues.folio.org/browse/STUTL-32