### PR TITLE
STUTL-34 Add `getSourceSuppressor` to build action suppressor based on an entry source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## IN PROGRESS
 
 * Add `getHeaderWithCredentials` for leverage cookie-based authentication in all API requests. Refs STUTL-32.
+* Add `getSourceSuppressor` to build action suppressor based on an entry sources. Refs STUTL-34.
 
 ## [5.2.1](https://github.com/folio-org/stripes-util/tree/v5.2.1) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-util/compare/v5.2.0...v5.2.1)

--- a/index.js
+++ b/index.js
@@ -4,5 +4,6 @@ export { default as exportCsv } from './lib/exportCsv';
 export { default as getFullName } from './lib/getFullName';
 export { default as parseJwt } from './lib/parseJwt';
 export { default as getHeaderWithCredentials } from './lib/getHeaderWithCredentials';
+export { default as getSourceSuppressor } from './lib/getSourceSuppressor';
 export * from './validators';
 export * from './lib/permission';

--- a/lib/getSourceSuppressor.js
+++ b/lib/getSourceSuppressor.js
@@ -1,0 +1,18 @@
+/**
+ * A factory that returns a suppressor function used in `<EditableList>`.
+ *
+ * The return function compares the entry source with the passed source (or list ofsources) and,
+ * if the values match, determines the result to be suppressed.
+ *
+ * @param {string | string[]} sourceValue
+ * @returns {function({ source: string }): boolean} Suppressor
+ */
+const getSourceSuppressor = (sourceValue) => (entry) => {
+  if (Array.isArray(sourceValue)) {
+    return sourceValue.includes(entry.source);
+  }
+
+  return entry.source === sourceValue;
+};
+
+export default getSourceSuppressor;

--- a/lib/getSourceSuppressor.js
+++ b/lib/getSourceSuppressor.js
@@ -1,8 +1,7 @@
 /**
  * A factory that returns a suppressor function used in `<EditableList>`.
  *
- * The return function compares the entry source with the passed source (or list ofsources) and,
- * if the values match, determines the result to be suppressed.
+ * The return function compares the entry source with the passed source (or list ofsources) and, if the values match, determines the result to be suppressed.
  *
  * @param {string | string[]} sourceValue
  * @returns {function({ source: string }): boolean} Suppressor

--- a/lib/getSourceSuppressor.test.js
+++ b/lib/getSourceSuppressor.test.js
@@ -1,0 +1,13 @@
+import getSourceSuppressor from './getSourceSuppressor';
+
+describe('getSourceSuppressor', () => {
+  it('should return \'true\' if action should be suppressed based on source', () => {
+    expect(getSourceSuppressor('local', { source: 'local' })).toBeTruthy();
+    expect(getSourceSuppressor(['marc', 'folio', 'consortium'], { source: 'folio' })).toBeTruthy();
+  });
+
+  it('should return \'false\' if action should NOT be suppressed based on source', () => {
+    expect(getSourceSuppressor('folio', { source: 'local' })).toBeTruthy();
+    expect(getSourceSuppressor(['marc', 'folio', 'consortium'], { source: 'local' })).toBeTruthy();
+  });
+});

--- a/lib/getSourceSuppressor.test.js
+++ b/lib/getSourceSuppressor.test.js
@@ -2,12 +2,12 @@ import getSourceSuppressor from './getSourceSuppressor';
 
 describe('getSourceSuppressor', () => {
   it('should return \'true\' if action should be suppressed based on source', () => {
-    expect(getSourceSuppressor('local', { source: 'local' })).toBeTruthy();
-    expect(getSourceSuppressor(['marc', 'folio', 'consortium'], { source: 'folio' })).toBeTruthy();
+    expect(getSourceSuppressor('local')({ source: 'local' })).toBeTruthy();
+    expect(getSourceSuppressor(['marc', 'folio', 'consortium'])({ source: 'folio' })).toBeTruthy();
   });
 
   it('should return \'false\' if action should NOT be suppressed based on source', () => {
-    expect(getSourceSuppressor('folio', { source: 'local' })).toBeTruthy();
-    expect(getSourceSuppressor(['marc', 'folio', 'consortium'], { source: 'local' })).toBeTruthy();
+    expect(getSourceSuppressor('folio')({ source: 'local' })).toBeFalsy();
+    expect(getSourceSuppressor(['marc', 'folio', 'consortium'])({ source: 'local' })).toBeFalsy();
   });
 });

--- a/test/jest/babel.config.js
+++ b/test/jest/babel.config.js
@@ -4,6 +4,6 @@ module.exports = {
     '@babel/preset-react',
   ],
   plugins: [
-    '@babel/plugin-proposal-class-properties',
+    '@babel/plugin-transform-class-properties',
   ],
 };


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/STUTL-34

Entries in a controlled vocabulary for some sources are not intended to be changed or deleted, only to be viewed. The `ui-inventory` app has a similar [util](https://github.com/folio-org/ui-inventory/blob/master/src/utils.js#L655) to suppress actions based on a source. To use this functionality in other applications, it will be useful to store it in a shared library.

Required by https://issues.folio.org/browse/UICONSET-21