### PR TITLE
STUTL-37: Add `escapeCqlValueAllowAsterisk` to only escape `" \ ^ ?` and not escape `*`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add `getSourceSuppressor` to build action suppressor based on an entry sources. Refs STUTL-34.
 * *BREAKING* Bump `react` to `v18`. Refs STUTL-35.
 * *BREAKING* `escapeCqlValue` escapes `" \ ^ * ?`. Refs STUTL-33.
+* Add `escapeCqlValueAllowAsterisk` to only escape `" \ ^ ?` and not escape `*`. Refs STUTL-37.
 
 ## [5.2.1](https://github.com/folio-org/stripes-util/tree/v5.2.1) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-util/compare/v5.2.0...v5.2.1)

--- a/lib/escapeCqlValueAllowAsterisk.js
+++ b/lib/escapeCqlValueAllowAsterisk.js
@@ -1,0 +1,10 @@
+/**
+ * Escape quote ("), backslash (\), caret(^), question mark (?) characters in a string
+ * by pre-pending them with a single backslash. Don't escape asterisk (*).
+ *
+ * @param string a string
+ * @return string the input string with the four special CQL characters masked
+ */
+export default function escapeCqlValueAllowAsterisk(str) {
+  return str.replace(/["\\^?]/g, c => '\\' + c);
+}

--- a/lib/escapeCqlValueAllowAsterisk.test.js
+++ b/lib/escapeCqlValueAllowAsterisk.test.js
@@ -1,0 +1,14 @@
+import { describe, expect, test } from '@jest/globals';
+
+import escapeCqlValueAllowAsterisk from './escapeCqlValueAllowAsterisk';
+
+describe('escapeCqlValueAllowAsterisk only escapes four CQL special characters and does not escape asterisk', () => {
+  test.each([
+    ['', ''],
+    ['foo_bar baz%', 'foo_bar baz%'],
+    ['f"o\\o^b*a?r', 'f\\"o\\\\o\\^b*a\\?r'],
+    ['?*^\\"??**^^\\\\""', '\\?*\\^\\\\\\"\\?\\?**\\^\\^\\\\\\\\\\"\\"'],
+  ])('escapeCqlValue(%p) should be %p', (raw, expected) => {
+    expect(escapeCqlValueAllowAsterisk(raw)).toEqual(expected);
+  });
+});


### PR DESCRIPTION
## Description
The asterisk has recently been escaped in `escapeCqlValue` https://github.com/folio-org/stripes-util/pull/69.
The [suggested solution](https://issues.folio.org/browse/STUTL-37?focusedCommentId=177131&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-177131) is to create a separate https://github.com/folio-org/stripes-util/pull/73 function to support the asterisk.

## Related PRs
[stripes-smart-components/pull/1382](https://github.com/folio-org/stripes-smart-components/pull/1382)

## Issue
[STUTL-37](https://issues.folio.org/browse/STUTL-37)