### PR TITLE
Revert "STUTL-33: escapeCqlValue for " \ ^ * ?"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 * Add `getHeaderWithCredentials` for leverage cookie-based authentication in all API requests. Refs STUTL-32.
 * Add `getSourceSuppressor` to build action suppressor based on an entry sources. Refs STUTL-34.
 * *BREAKING* Bump `react` to `v18`. Refs STUTL-35.
-* *BREAKING* `escapeCqlValue` escapes `" \ ^ * ?`. Refs STUTL-33.
 
 ## [5.2.1](https://github.com/folio-org/stripes-util/tree/v5.2.1) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-util/compare/v5.2.0...v5.2.1)

--- a/lib/escapeCqlValue.js
+++ b/lib/escapeCqlValue.js
@@ -1,11 +1,10 @@
 /**
- * Escape quote ("), backslash (\), caret(^), star (*) and question mark (?)
- * characters in a string by pre-pending them with a single backslash.
- * See https://www.loc.gov/standards/sru/cql/contextSets/theCqlContextSet.html
+ * Escape quote (") and backslash (\) characters in a string by pre-pending
+ * them with a single backslash.
  *
  * @param string a string
- * @return string the input string with the five special CQL characters masked
+ * @return string the input string with quotes and backslashes escaped
  */
 export default function escapeCqlValue(str) {
-  return str.replace(/["\\^*?]/g, c => '\\' + c);
+  return str.replace(/"|\\/g, c => '\\' + c);
 }

--- a/lib/escapeCqlValue.test.js
+++ b/lib/escapeCqlValue.test.js
@@ -2,13 +2,19 @@ import { describe, expect, test } from '@jest/globals';
 
 import escapeCqlValue from './escapeCqlValue';
 
-describe('escapeCqlValue masks all five CQL special characters', () => {
-  test.each([
-    ['', ''],
-    ['foo_bar baz%', 'foo_bar baz%'],
-    ['f"o\\o^b*a?r', 'f\\"o\\\\o\\^b\\*a\\?r'],
-    ['?*^\\"??**^^\\\\""', '\\?\\*\\^\\\\\\"\\?\\?\\*\\*\\^\\^\\\\\\\\\\"\\"'],
-  ])('escapeCqlValue(%p) should be %p', (raw, expected) => {
-    expect(escapeCqlValue(raw)).toEqual(expected);
+describe('correctly escapes CQL special characters', () => {
+  test('does not modify non-special strings', () => {
+    const str = 'abc';
+    expect(escapeCqlValue(str)).toEqual(str);
+  });
+
+  test('escapes quote (") with a backslash', () => {
+    const str = 'a"b"c';
+    expect(escapeCqlValue(str)).toEqual('a\\"b\\"c');
+  });
+
+  test('escapes backslash (\\) with a backslash', () => {
+    const str = 'a\\b\\c';
+    expect(escapeCqlValue(str)).toEqual('a\\\\b\\\\c');
   });
 });


### PR DESCRIPTION
Reverts folio-org/stripes-util#69

This appears to be a likely cause of > [150 e2e test failures](https://jenkins-aws.indexdata.com/job/Testing/job/Scheduled_Cypress_Tests/360/allure/) when tests rely on an asterisk as part of a wildcard search. We may eventually decide to keep this work, alongside a function that permits the asterisk, as outlined in [STUTL-37](https://issues.folio.org/browse/STUTL-37) / #73, but we'll want to rearrange the order of operations (implement that function, then convert existing search code to use that function, and only then implement the breaking change outlined in STUTL-33). 

FYI: @julianladisch 