### PR TITLE
STUTL-41 prune unused deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add `getHeaderWithCredentials` for leverage cookie-based authentication in all API requests. Refs STUTL-32.
 * Add `getSourceSuppressor` to build action suppressor based on an entry sources. Refs STUTL-34.
 * *BREAKING* Bump `react` to `v18`. Refs STUTL-35.
+* Prune unused deps, including `engines.node`. Refs STUTL-41.
 
 ## [5.2.1](https://github.com/folio-org/stripes-util/tree/v5.2.1) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-util/compare/v5.2.0...v5.2.1)

--- a/package.json
+++ b/package.json
@@ -15,9 +15,6 @@
     "test": "yarn run test:unit",
     "lint": "eslint ."
   },
-  "engines": {
-    "node": ">=14.0.0"
-  },
   "devDependencies": {
     "@babel/core": "^7.18.5",
     "@babel/eslint-parser": "^7.18.2",
@@ -25,12 +22,8 @@
     "@folio/stripes-cli": "^3.0.0",
     "@jest/globals": "^26.4.2",
     "babel-jest": "^26.3.0",
-    "eslint-import-resolver-typescript": "^3.5.5",
-    "eslint-import-resolver-webpack": "^0.13.2",
     "jest": "^26.4.2",
-    "jest-junit": "^11.1.0",
-    "react-test-renderer": "^16.13.1",
-    "webpack": "^4.10.2"
+    "jest-junit": "^11.1.0"
   },
   "dependencies": {
     "json2csv": "^4.2.1",


### PR DESCRIPTION
Prune unused deps, including `engines.node`. This is a web application not a node application, thus, node is not a production dependency.

Refs [STUTL-41](https://issues.folio.org/browse/STUTL-41)