### PR TITLE
STUTL-44 Update 'effectiveCallNumber' to include item's 'Display summary' in the output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 6.1.0 IN PROGRESS
 
+* Update `effectiveCallNumber` to include item's "Display summary" in the output. Refs STUTL-44.
+
 ## [6.0.0](https://github.com/folio-org/stripes-util/tree/v6.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-util/compare/v5.2.1...v6.0.0)
 

--- a/lib/effectiveCallNumber.js
+++ b/lib/effectiveCallNumber.js
@@ -8,6 +8,7 @@ import { compact } from 'lodash';
  *   <EffectiveCallNumberPrefix>
  *   <EffectiveCallNumber>
  *   <EffectiveCallNumberSuffix>
+ *   <DisplaySummary>
  *   <Volume>
  *   <Enumeration>
  *   <Chronology>
@@ -28,6 +29,7 @@ export default function effectiveCallNumber(instanceItem) {
     prefix,
     callNumber,
     suffix,
+    rootItem?.displaySummary,
     rootItem?.volume,
     rootItem?.enumeration,
     rootItem?.chronology,

--- a/lib/effectiveCallNumber.test.js
+++ b/lib/effectiveCallNumber.test.js
@@ -6,6 +6,7 @@ const item = {
     suffix: 'suffix',
     callNumber: 'callNumber',
   },
+  displaySummary: 'displaySummary',
   volume: 'volume',
   enumeration: 'enumeration',
   chronology: 'chronology',
@@ -14,7 +15,7 @@ const item = {
 
 describe('handles /inventory/items/item-id shaped items', () => {
   test('fully populated element', () => {
-    expect(effectiveCallNumber(item)).toEqual('prefix callNumber suffix volume enumeration chronology copyNumber');
+    expect(effectiveCallNumber(item)).toEqual('prefix callNumber suffix displaySummary volume enumeration chronology copyNumber');
   });
 
   describe('effectiveCallNumberComponents override callNumberComponents', () => {
@@ -25,7 +26,7 @@ describe('handles /inventory/items/item-id shaped items', () => {
       callNumber: 'ecn-callNumber',
     };
 
-    expect(effectiveCallNumber(pItem)).toEqual('ecn-prefix ecn-callNumber ecn-suffix volume enumeration chronology copyNumber');
+    expect(effectiveCallNumber(pItem)).toEqual('ecn-prefix ecn-callNumber ecn-suffix displaySummary volume enumeration chronology copyNumber');
   });
 
   test('without prefix', () => {
@@ -33,7 +34,7 @@ describe('handles /inventory/items/item-id shaped items', () => {
     const pComponents = { ...item.callNumberComponents };
     delete pComponents.prefix;
     pItem.callNumberComponents = pComponents;
-    expect(effectiveCallNumber(pItem)).toEqual('callNumber suffix volume enumeration chronology copyNumber');
+    expect(effectiveCallNumber(pItem)).toEqual('callNumber suffix displaySummary volume enumeration chronology copyNumber');
   });
 
   test('without callNumber', () => {
@@ -41,7 +42,7 @@ describe('handles /inventory/items/item-id shaped items', () => {
     const pComponents = { ...item.callNumberComponents };
     delete pComponents.callNumber;
     pItem.callNumberComponents = pComponents;
-    expect(effectiveCallNumber(pItem)).toEqual('prefix suffix volume enumeration chronology copyNumber');
+    expect(effectiveCallNumber(pItem)).toEqual('prefix suffix displaySummary volume enumeration chronology copyNumber');
   });
 
   test('without suffix', () => {
@@ -49,37 +50,43 @@ describe('handles /inventory/items/item-id shaped items', () => {
     const pComponents = { ...item.callNumberComponents };
     delete pComponents.suffix;
     pItem.callNumberComponents = pComponents;
-    expect(effectiveCallNumber(pItem)).toEqual('prefix callNumber volume enumeration chronology copyNumber');
+    expect(effectiveCallNumber(pItem)).toEqual('prefix callNumber displaySummary volume enumeration chronology copyNumber');
   });
 
   test('without volume', () => {
     const pItem = { ...item };
     delete pItem.volume;
-    expect(effectiveCallNumber(pItem)).toEqual('prefix callNumber suffix enumeration chronology copyNumber');
+    expect(effectiveCallNumber(pItem)).toEqual('prefix callNumber suffix displaySummary enumeration chronology copyNumber');
   });
 
   test('without enumeration', () => {
     const pItem = { ...item };
     delete pItem.enumeration;
-    expect(effectiveCallNumber(pItem)).toEqual('prefix callNumber suffix volume chronology copyNumber');
+    expect(effectiveCallNumber(pItem)).toEqual('prefix callNumber suffix displaySummary volume chronology copyNumber');
   });
 
   test('without chronology', () => {
     const pItem = { ...item };
     delete pItem.chronology;
-    expect(effectiveCallNumber(pItem)).toEqual('prefix callNumber suffix volume enumeration copyNumber');
+    expect(effectiveCallNumber(pItem)).toEqual('prefix callNumber suffix displaySummary volume enumeration copyNumber');
   });
 
   test('without copyNumber', () => {
     const pItem = { ...item };
     delete pItem.copyNumber;
-    expect(effectiveCallNumber(pItem)).toEqual('prefix callNumber suffix volume enumeration chronology');
+    expect(effectiveCallNumber(pItem)).toEqual('prefix callNumber suffix displaySummary volume enumeration chronology');
+  });
+
+  test('without displaySummary', () => {
+    const pItem = { ...item };
+    delete pItem.displaySummary;
+    expect(effectiveCallNumber(pItem)).toEqual('prefix callNumber suffix volume enumeration chronology copyNumber');
   });
 });
 
 describe('handles circulation/loans shaped items', () => {
   const loanItem = { item };
   test('fully populated element', () => {
-    expect(effectiveCallNumber(loanItem)).toEqual('prefix callNumber suffix volume enumeration chronology copyNumber');
+    expect(effectiveCallNumber(loanItem)).toEqual('prefix callNumber suffix displaySummary volume enumeration chronology copyNumber');
   });
 });


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/STUTL-44

"Effective call number" includes a "Display summary" value when displayed on the item's view or form.