### PR TITLE
STUTL-48 exportCSV - render download link to OverlayContainer rather than document.body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for stripes-util
 
 ## 6.3.0 IN PROGRESS
+* `exportCSV` render download link to `OverlayContainer` to allow click to work and avoid focus-trapping of stripes modals. Refs STUTL-48.
 
 ## [6.2.0](https://github.com/folio-org/stripes-util/tree/v6.2.0) (2024-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-util/compare/v6.1.0...v6.2.0)

--- a/lib/exportCsv.js
+++ b/lib/exportCsv.js
@@ -13,10 +13,13 @@ function triggerDownload(csv, fileTitle) {
       link.setAttribute('href', url);
       link.setAttribute('download', exportedFilename);
       link.style.visibility = 'hidden';
-      document.body.appendChild(link);
+      const linkContainer = document.getElementById('OverlayContainer') || document.body;
+      linkContainer.appendChild(link);
       window.setTimeout(() => {
+        const currentFocused = document.activeElement;
         link.click();
-        document.body.removeChild(link);
+        currentFocused.focus();
+        linkContainer.removeChild(link);
       }, 50); // Need to debounce this click event from others (Pane actionMenuItems dropdown)
     } else {
       console.error('Failed to trigger download for CSV data'); // eslint-disable-line no-console


### PR DESCRIPTION
Related to https://github.com/folio-org/stripes-components/pull/2400