### PR TITLE
STUTL-51: Add convertToSlipData and supporting functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * `exportCSV` render download link to `OverlayContainer` to allow click to work and avoid focus-trapping of stripes modals. Refs STUTL-48.
 * *BREAKING* Upgrade `@folio/stripes-*` dependencies. Refs STUTL-52.
+* Add `convertToSlipData` and supporting functions. Refs STUTL-51.
 
 ## [6.2.0](https://github.com/folio-org/stripes-util/tree/v6.2.0) (2024-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-util/compare/v6.1.0...v6.2.0)

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+export { default as convertToSlipData } from './lib/convertToSlipData';
 export { default as effectiveCallNumber } from './lib/effectiveCallNumber';
 export { default as escapeCqlValue } from './lib/escapeCqlValue';
 export { default as escapeCqlWildcards } from './lib/escapeCqlWildcards';

--- a/lib/convertToSlipData.js
+++ b/lib/convertToSlipData.js
@@ -1,0 +1,97 @@
+import moment from 'moment-timezone';
+
+const DEFAULT_VIEW_VALUE = '';
+
+export const STAFF_SLIP_TYPES = {
+  HOLD: 'Hold',
+};
+
+export const buildLocaleDateAndTime = (dateTime, timezone, locale) => (
+  moment(dateTime)
+    .tz(timezone)
+    .locale(locale)
+    .format('L LT')
+);
+
+export const convertToSlipData = (source = {}, intl, timeZone, locale, slipName = STAFF_SLIP_TYPES.HOLD) => {
+  const {
+    item = {},
+    request = {},
+    requester = {},
+    currentDateTime = null,
+  } = source;
+
+  const DEFAULT_DATE_OPTIONS = {
+    timeZone,
+    locale,
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+  };
+
+  const slipData = {
+    'staffSlip.Name': slipName,
+    'staffSlip.currentDateTime': buildLocaleDateAndTime(currentDateTime, timeZone, locale),
+    'requester.firstName': requester.firstName,
+    'requester.lastName': requester.lastName,
+    'requester.middleName': requester.middleName,
+    'requester.preferredFirstName': requester.preferredFirstName ? requester.preferredFirstName : requester.firstName,
+    'requester.patronGroup': requester.patronGroup,
+    'requester.addressLine1': requester.addressLine1,
+    'requester.addressLine2': requester.addressLine2,
+    'requester.country': requester.countryId
+      ? intl.formatMessage({ id: `stripes-components.countries.${requester.countryId}` })
+      : DEFAULT_VIEW_VALUE,
+    'requester.city': requester.city,
+    'requester.stateProvRegion': requester.region,
+    'requester.zipPostalCode': requester.postalCode,
+    'requester.barcode': requester.barcode,
+    'requester.barcodeImage': requester.barcode ? `<Barcode>${requester.barcode}</Barcode>` : DEFAULT_VIEW_VALUE,
+    'requester.departments': requester.departments,
+    'item.title': item.title,
+    'item.primaryContributor': item.primaryContributor,
+    'item.allContributors': item.allContributors,
+    'item.barcode': item.barcode,
+    'item.barcodeImage': `<Barcode>${item.barcode}</Barcode>`,
+    'item.callNumber': item.callNumber,
+    'item.callNumberPrefix': item.callNumberPrefix,
+    'item.callNumberSuffix': item.callNumberSuffix,
+    'item.displaySummary': item.displaySummary,
+    'item.enumeration': item.enumeration,
+    'item.volume': item.volume,
+    'item.chronology': item.chronology,
+    'item.copy': item.copy,
+    'item.yearCaption': item.yearCaption,
+    'item.materialType': item.materialType,
+    'item.loanType': item.loanType,
+    'item.numberOfPieces': item.numberOfPieces,
+    'item.descriptionOfPieces': item.descriptionOfPieces,
+    'item.lastCheckedInDateTime': item.lastCheckedInDateTime
+      ? intl.formatDate(item.lastCheckedInDateTime, DEFAULT_DATE_OPTIONS)
+      : item.lastCheckedInDateTime,
+    'item.fromServicePoint': item.fromServicePoint,
+    'item.toServicePoint': item.toServicePoint,
+    'item.effectiveLocationInstitution': item.effectiveLocationInstitution,
+    'item.effectiveLocationCampus': item.effectiveLocationCampus,
+    'item.effectiveLocationLibrary': item.effectiveLocationLibrary,
+    'item.effectiveLocationSpecific': item.effectiveLocationSpecific,
+    'item.effectiveLocationPrimaryServicePointName': item.effectiveLocationPrimaryServicePointName,
+    'request.servicePointPickup': request.servicePointPickup,
+    'request.deliveryAddressType': request.deliveryAddressType,
+    'request.requestExpirationDate': request.requestExpirationDate
+      ? intl.formatDate(request.requestExpirationDate, DEFAULT_DATE_OPTIONS)
+      : request.requestExpirationDate,
+    'request.requestDate': request.requestDate ? intl.formatDate(request.requestDate, DEFAULT_DATE_OPTIONS) : request.requestDate,
+    'request.holdShelfExpirationDate': request.holdShelfExpirationDate
+      ? intl.formatDate(request.holdShelfExpirationDate, DEFAULT_DATE_OPTIONS)
+      : request.holdShelfExpirationDate,
+    'request.requestID': request.requestID,
+    'request.patronComments': request.patronComments,
+  };
+
+  return slipData;
+};
+
+export default convertToSlipData;

--- a/lib/convertToSlipData.js
+++ b/lib/convertToSlipData.js
@@ -1,17 +1,8 @@
-import moment from 'moment-timezone';
-
 const DEFAULT_VIEW_VALUE = '';
 
 export const STAFF_SLIP_TYPES = {
   HOLD: 'Hold',
 };
-
-export const buildLocaleDateAndTime = (dateTime, timezone, locale) => (
-  moment(dateTime)
-    .tz(timezone)
-    .locale(locale)
-    .format('L LT')
-);
 
 export const convertToSlipData = (source = {}, intl, timeZone, locale, slipName = STAFF_SLIP_TYPES.HOLD) => {
   const {
@@ -30,10 +21,14 @@ export const convertToSlipData = (source = {}, intl, timeZone, locale, slipName 
     hour: 'numeric',
     minute: 'numeric',
   };
+  const CURRENT_DATE_TIME_DATE_OPTIONS = {
+    ...DEFAULT_DATE_OPTIONS,
+    month: 'numeric',
+  };
 
   const slipData = {
     'staffSlip.Name': slipName,
-    'staffSlip.currentDateTime': buildLocaleDateAndTime(currentDateTime, timeZone, locale),
+    'staffSlip.currentDateTime': intl.formatDate(currentDateTime, CURRENT_DATE_TIME_DATE_OPTIONS),
     'requester.firstName': requester.firstName,
     'requester.lastName': requester.lastName,
     'requester.middleName': requester.middleName,

--- a/lib/convertToSlipData.test.js
+++ b/lib/convertToSlipData.test.js
@@ -1,0 +1,193 @@
+import {
+  buildLocaleDateAndTime,
+  convertToSlipData,
+  STAFF_SLIP_TYPES,
+} from './convertToSlipData';
+
+export const STAFF_SLIP_WITH_OUT_DATA = {
+  'item.allContributors': undefined,
+  'item.barcode': undefined,
+  'item.barcodeImage': '<Barcode>undefined</Barcode>',
+  'item.callNumber': undefined,
+  'item.callNumberPrefix': undefined,
+  'item.callNumberSuffix': undefined,
+  'item.chronology': undefined,
+  'item.copy': undefined,
+  'item.descriptionOfPieces': undefined,
+  'item.displaySummary': undefined,
+  'item.effectiveLocationCampus': undefined,
+  'item.effectiveLocationInstitution': undefined,
+  'item.effectiveLocationLibrary': undefined,
+  'item.effectiveLocationPrimaryServicePointName': undefined,
+  'item.effectiveLocationSpecific': undefined,
+  'item.enumeration': undefined,
+  'item.fromServicePoint': undefined,
+  'item.lastCheckedInDateTime': undefined,
+  'item.loanType': undefined,
+  'item.materialType': undefined,
+  'item.numberOfPieces': undefined,
+  'item.primaryContributor': undefined,
+  'item.title': undefined,
+  'item.toServicePoint': undefined,
+  'item.volume': undefined,
+  'item.yearCaption': undefined,
+  'request.deliveryAddressType': undefined,
+  'request.holdShelfExpirationDate': undefined,
+  'request.patronComments': undefined,
+  'request.requestDate': undefined,
+  'request.requestExpirationDate': undefined,
+  'request.requestID': undefined,
+  'request.servicePointPickup': undefined,
+  'requester.addressLine1': undefined,
+  'requester.addressLine2': undefined,
+  'requester.barcode': undefined,
+  'requester.barcodeImage': '',
+  'requester.city': undefined,
+  'requester.country': '',
+  'requester.departments': undefined,
+  'requester.firstName': undefined,
+  'requester.lastName': undefined,
+  'requester.middleName': undefined,
+  'requester.patronGroup': undefined,
+  'requester.preferredFirstName': undefined,
+  'requester.stateProvRegion': undefined,
+  'requester.zipPostalCode': undefined,
+  'staffSlip.Name': STAFF_SLIP_TYPES.HOLD,
+  'staffSlip.currentDateTime': 'Invalid date',
+};
+
+export const SOURCE_FOR_STAFF_SLIP_DATA = {
+  currentDateTime: '2024-12-31T24:00:00.000+00:00',
+  requester: {
+    firstName: 'requester.firstName',
+    lastName: 'requester.lastName',
+    middleName: 'requester.middleName',
+    preferredFirstName: 'requester.preferredFirstName',
+    patronGroup: 'requester.patronGroup',
+    addressLine1: 'requester.addressLine1',
+    addressLine2: 'requester.addressLine2',
+    countryId: 'requester.countryId',
+    city: 'requester.city',
+    region: 'requester.region',
+    postalCode: 'requester.postalCode',
+    barcode: 'requester.barcode',
+    departments: 'requester.departments',
+  },
+  item: {
+    title: 'item.title',
+    primaryContributor: 'item.primaryContributor',
+    allContributors: 'item.allContributors',
+    barcode: 'item.barcode',
+    callNumber: 'item.callNumber',
+    callNumberPrefix: 'item.callNumberPrefix',
+    callNumberSuffix: 'item.callNumberSuffix',
+    displaySummary: 'item.displaySummary',
+    enumeration: 'item.enumeration',
+    volume: 'item.volume',
+    chronology: 'item.chronology',
+    copy: 'item.copy',
+    yearCaption: 'item.yearCaption',
+    materialType: 'item.materialType',
+    loanType: 'item.loanType',
+    numberOfPieces: 'item.numberOfPieces',
+    descriptionOfPieces: 'item.descriptionOfPieces',
+    lastCheckedInDateTime: '2024-12-31T24:00:00.000+00:00',
+    fromServicePoint: 'item.fromServicePoint',
+    toServicePoint: 'item.toServicePoint',
+    effectiveLocationInstitution: 'item.effectiveLocationInstitution',
+    effectiveLocationCampus: 'item.effectiveLocationCampus',
+    effectiveLocationLibrary: 'item.effectiveLocationLibrary',
+    effectiveLocationSpecific: 'item.effectiveLocationSpecific',
+    effectiveLocationPrimaryServicePointName: 'item.effectiveLocationPrimaryServicePointName',
+  },
+  request: {
+    servicePointPickup: 'request.servicePointPickup',
+    deliveryAddressType: 'request.deliveryAddressType',
+    requestExpirationDate: '2024-12-31T24:00:00.000+00:00',
+    requestDate: '2024-12-31T24:00:00.000+00:00',
+    holdShelfExpirationDate: '2024-12-31T24:00:00.000+00:00',
+    requestID: 'request.requestID',
+    patronComments: 'request.patronComments',
+  },
+};
+
+export const STAFF_SLIP_DATA = {
+  'item.allContributors': 'item.allContributors',
+  'item.barcode': 'item.barcode',
+  'item.barcodeImage': '<Barcode>item.barcode</Barcode>',
+  'item.callNumber': 'item.callNumber',
+  'item.callNumberPrefix': 'item.callNumberPrefix',
+  'item.callNumberSuffix': 'item.callNumberSuffix',
+  'item.chronology': 'item.chronology',
+  'item.copy': 'item.copy',
+  'item.descriptionOfPieces': 'item.descriptionOfPieces',
+  'item.displaySummary': 'item.displaySummary',
+  'item.effectiveLocationCampus': 'item.effectiveLocationCampus',
+  'item.effectiveLocationInstitution': 'item.effectiveLocationInstitution',
+  'item.effectiveLocationLibrary': 'item.effectiveLocationLibrary',
+  'item.effectiveLocationPrimaryServicePointName': 'item.effectiveLocationPrimaryServicePointName',
+  'item.effectiveLocationSpecific': 'item.effectiveLocationSpecific',
+  'item.enumeration': 'item.enumeration',
+  'item.fromServicePoint': 'item.fromServicePoint',
+  'item.lastCheckedInDateTime': '2024-12-31T24:00:00.000+00:00',
+  'item.loanType': 'item.loanType',
+  'item.materialType': 'item.materialType',
+  'item.numberOfPieces': 'item.numberOfPieces',
+  'item.primaryContributor': 'item.primaryContributor',
+  'item.title': 'item.title',
+  'item.toServicePoint': 'item.toServicePoint',
+  'item.volume': 'item.volume',
+  'item.yearCaption': 'item.yearCaption',
+  'request.deliveryAddressType': 'request.deliveryAddressType',
+  'request.holdShelfExpirationDate': '2024-12-31T24:00:00.000+00:00',
+  'request.patronComments': 'request.patronComments',
+  'request.requestDate': '2024-12-31T24:00:00.000+00:00',
+  'request.requestExpirationDate': '2024-12-31T24:00:00.000+00:00',
+  'request.requestID': 'request.requestID',
+  'request.servicePointPickup': 'request.servicePointPickup',
+  'requester.addressLine1': 'requester.addressLine1',
+  'requester.addressLine2': 'requester.addressLine2',
+  'requester.barcode': 'requester.barcode',
+  'requester.barcodeImage': '<Barcode>requester.barcode</Barcode>',
+  'requester.city': 'requester.city',
+  'requester.country': 'stripes-components.countries.requester.countryId',
+  'requester.departments': 'requester.departments',
+  'requester.firstName': 'requester.firstName',
+  'requester.lastName': 'requester.lastName',
+  'requester.middleName': 'requester.middleName',
+  'requester.patronGroup': 'requester.patronGroup',
+  'requester.preferredFirstName': 'requester.preferredFirstName',
+  'requester.stateProvRegion': 'requester.region',
+  'requester.zipPostalCode': 'requester.postalCode',
+  'staffSlip.Name': STAFF_SLIP_TYPES.HOLD,
+  'staffSlip.currentDateTime': '01/01/2025 12:00 AM',
+};
+
+describe('buildLocaleDateAndTime', () => {
+  const dateTime = '2024-12-31T24:00:00.000+00:00';
+  const timezone = 'UTC';
+  const locale = 'en-US';
+
+  it('should return date with locale date and time', () => {
+    expect(buildLocaleDateAndTime(dateTime, timezone, locale)).toEqual('01/01/2025 12:00 AM');
+  });
+});
+
+describe('convertToSlipData', () => {
+  const intl = {
+    formatDate: (date) => (date),
+    formatMessage: ({ id }) => (id),
+  };
+  const timeZone = 'UTC';
+  const locale = 'en-US';
+
+  it('should return slip data with out value', () => {
+    const source = {};
+
+    expect(convertToSlipData(source, intl, timeZone, locale)).toEqual(STAFF_SLIP_WITH_OUT_DATA);
+  });
+
+  it('should return slip data with value', () => {
+    expect(convertToSlipData(SOURCE_FOR_STAFF_SLIP_DATA, intl, timeZone, locale)).toEqual(STAFF_SLIP_DATA);
+  });
+});

--- a/lib/convertToSlipData.test.js
+++ b/lib/convertToSlipData.test.js
@@ -1,5 +1,4 @@
 import {
-  buildLocaleDateAndTime,
   convertToSlipData,
   STAFF_SLIP_TYPES,
 } from './convertToSlipData';
@@ -53,7 +52,7 @@ export const STAFF_SLIP_WITH_OUT_DATA = {
   'requester.stateProvRegion': undefined,
   'requester.zipPostalCode': undefined,
   'staffSlip.Name': STAFF_SLIP_TYPES.HOLD,
-  'staffSlip.currentDateTime': 'Invalid date',
+  'staffSlip.currentDateTime': null,
 };
 
 export const SOURCE_FOR_STAFF_SLIP_DATA = {
@@ -160,18 +159,8 @@ export const STAFF_SLIP_DATA = {
   'requester.stateProvRegion': 'requester.region',
   'requester.zipPostalCode': 'requester.postalCode',
   'staffSlip.Name': STAFF_SLIP_TYPES.HOLD,
-  'staffSlip.currentDateTime': '01/01/2025 12:00 AM',
+  'staffSlip.currentDateTime': '2024-12-31T24:00:00.000+00:00',
 };
-
-describe('buildLocaleDateAndTime', () => {
-  const dateTime = '2024-12-31T24:00:00.000+00:00';
-  const timezone = 'UTC';
-  const locale = 'en-US';
-
-  it('should return date with locale date and time', () => {
-    expect(buildLocaleDateAndTime(dateTime, timezone, locale)).toEqual('01/01/2025 12:00 AM');
-  });
-});
 
 describe('convertToSlipData', () => {
   const intl = {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "json2csv": "^4.2.1",
     "lodash": "^4.17.4",
+    "moment-timezone": "^0.5.47",
     "query-string": "^7.1.2"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "json2csv": "^4.2.1",
     "lodash": "^4.17.4",
-    "moment-timezone": "^0.5.47",
     "query-string": "^7.1.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Purpose
Add convertToSlipData and supporting functions.
In settings -> circulation -> staff slips we create template that contain token. When we try print this template in our modules checkin, requests, requests-mediated and etc we need match real data and token from template. For this match responsibel convertToSlipData function and supporting functions. And in each of modules checkin, requests, requests-mediated and etc we have own exemplar of  convertToSlipData function and supporting functions. This mean that when we add new token in settings -> circulation -> staff slips we need updete convertToSlipData function in all modulel checkin, requests, requests-mediated and etc. For resolve this problem we want move convertToSlipData function and supporting functions to one plase and just reuse it in modulel checkin, requests, requests-mediated and etc.

# Refs
https://issues.folio.org/browse/STUTL-51
